### PR TITLE
Support get_latest_build_number in the GCS Artifact Registry driver

### DIFF
--- a/lib/kube_deploy_tools/artifact_registry/driver_gcs.rb
+++ b/lib/kube_deploy_tools/artifact_registry/driver_gcs.rb
@@ -29,15 +29,21 @@ module KubeDeployTools
       local_artifact_path
     end
 
+    def get_registry_build_path(project:)
+      # NOTE: If the naming format changes, it represents a breaking change
+      # where all past clients will not be able to list/download new builds
+      # and new clients will not be able to list/download old builds. Change
+      # with caution.
+      #
+      "#{@bucket}/project/#{project}/build"
+    end
+
     def get_registry_artifact_path(name:, flavor:, project:, build_number:)
       # NOTE(joshk): If the naming format changes, it represents a breaking
       # change where all past clients will not be able to download new builds and
       # new clients will not be able to download old builds. Change with caution.
       #
-      if flavor.empty? && name.empty? && build_number.empty?
-        return "#{@bucket}/project/#{project}/build/"
-      end
-      "#{@bucket}/project/#{project}/build/#{build_number}/artifact/#{get_artifact_name(name: name, flavor: flavor)}"
+      "#{get_registry_build_path(project: project)}/#{build_number}/artifact/#{get_artifact_name(name: name, flavor: flavor)}"
     end
 
     def get_artifact_name(name:, flavor:)
@@ -88,7 +94,7 @@ module KubeDeployTools
     end
 
     def get_latest_build_number(project)
-      out = Shellrunner.check_call('gsutil', 'ls', get_registry_artifact_path(name: '', flavor: '', project: project, build_number: ''))
+      out = Shellrunner.check_call('gsutil', 'ls', get_registry_build_path(project: project))
 
       # pick out the build numbers from the list
       build_regex = /([0-9]+)\/$/

--- a/lib/kube_deploy_tools/artifact_registry/driver_gcs.rb
+++ b/lib/kube_deploy_tools/artifact_registry/driver_gcs.rb
@@ -85,7 +85,7 @@ module KubeDeployTools
     end
 
     def get_latest_build_number(project)
-      out, err, status = Shellrunner.run_call('gsutil ls -l #{@bucket}/project/#{project}/build/')
+      out, err, status = Shellrunner.run_call('gsutil', 'ls -l', '#{@bucket}/project/#{project}/build/')
 
       if !status.success?
         raise "Failed to list latest builds for project"

--- a/lib/kube_deploy_tools/artifact_registry/driver_gcs.rb
+++ b/lib/kube_deploy_tools/artifact_registry/driver_gcs.rb
@@ -84,6 +84,22 @@ module KubeDeployTools
       output_path
     end
 
+    def get_latest_build_number(project)
+      out, err, status = Shellrunner.run_call('gsutil ls -l #{@bucket}/project/#{project}/build/')
+
+      if !status.success?
+        raise "Failed to list latest builds for project"
+      end
+      # pick out the build numbers from the list
+      build_regex = /[0-9]+\/$/
+      build_entries = out.scan(build_number_regex)
+      build_number_pattern = /^\d+/  # exclude last `/`
+      build_entries.
+      map { |x| x.match(build_number_pattern).to_s.to_i }.
+      max.
+      to_s
+    end
+
     def upload(local_dir:, name:, flavor:, project:, build_number:)
       # Pack up contents of each flavor_dir to a correctly named artifact.
       flavor_dir = File.join(local_dir, "#{name}_#{flavor}")


### PR DESCRIPTION
Context:
When using a GCS artifact registry, we currently can't reference the latest build
unless manually supplied. This PR adds the method to be able to do so.

Testing:
Tested locally. 


