### PR TITLE
Support updated kubectl --dry-run values

### DIFF
--- a/lib/kube_deploy_tools/deploy.rb
+++ b/lib/kube_deploy_tools/deploy.rb
@@ -64,10 +64,9 @@ module KubeDeployTools
     end
 
     def do_deploy(dry_run)
-      success = false
       Logger.reset
       Logger.phase_heading('Initializing deploy')
-      Logger.warn('Running in dry-run mode') if dry_run
+      Logger.warn('Running in dry-run mode') if dry_run != 'none'
 
       if !@namespace.nil? && @namespace != 'default'
         Logger.warn("Deploying to non-default Namespace: #{@namespace}")
@@ -98,7 +97,7 @@ module KubeDeployTools
       success
     end
 
-    def run(dry_run: true)
+    def run(dry_run: 'client')
       do_deploy(dry_run)
     end
 
@@ -161,7 +160,7 @@ module KubeDeployTools
       raise FatalDeploymentError, "Template '#{filepath}' cannot be parsed"
     end
 
-    def kubectl_apply(resources, dry_run: true)
+    def kubectl_apply(resources, dry_run: 'client')
       resources.each do |resource|
         @max_retries.times do |try|
           args = ['apply', '-f', resource.filepath, "--dry-run=#{dry_run}"]


### PR DESCRIPTION
As of [kubernetes version 1.23](https://kubernetes.io/docs/reference/kubectl/overview/) ([PR](https://github.com/kubernetes/kubernetes/pull/105327)) the only supported values for the `--dry-run` flag are `none, client, server`, with the deprecation of the previous boolean values beginning with [version 1.18](https://github.com/kubernetes/enhancements/tree/master/keps/sig-api-machinery/576-dry-run#removing-a-deprecated-flag).

This change adds support for these values and maps the current KDT values accordingly:
- `true` -> `client`
- `false` -> `none`